### PR TITLE
Major SeedProvider Refactor + Explicit AtumCreateWorldScreen Job

### DIFF
--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -116,7 +116,9 @@ public class Atum implements ClientModInitializer {
         if (!SEED_FAILURES.isEmpty()) {
             if (isRunning()) {
                 stopRunning();
-                if (client.world == null) client.openScreen(null);
+                if (client.world == null) {
+                    client.openScreen(null);
+                }
             }
             while (!SEED_FAILURES.isEmpty()) {
                 getSeedProvider().onFail(SEED_FAILURES.poll());

--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -14,8 +14,10 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class Atum implements ClientModInitializer {
     public static final Logger LOGGER = LogManager.getLogger();
@@ -28,6 +30,7 @@ public class Atum implements ClientModInitializer {
     private static boolean running = false;
     private static boolean shouldReset;
 
+    public static final Queue<Throwable> SEED_FAILURES = new ConcurrentLinkedQueue<>();
     public static final Set<CompletableFuture<String>> SEED_FUTURES = new ConcurrentSet<>();
     private static final SeedProvider DEFAULT_SEED_PROVIDER = () -> CompletableFuture.completedFuture(Atum.config.seed);
     private static SeedProvider seedProvider = DEFAULT_SEED_PROVIDER;
@@ -106,6 +109,19 @@ public class Atum implements ClientModInitializer {
     public static void cancelAllSeeds() {
         // Copy the collection to avoid modification during iteration
         new ArrayList<>(SEED_FUTURES).forEach(f -> f.cancel(true));
+    }
+
+    public static void checkSeedFailures() {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (!SEED_FAILURES.isEmpty()) {
+            if (isRunning()) {
+                stopRunning();
+                if (client.world == null) client.openScreen(null);
+            }
+        }
+        while (!SEED_FAILURES.isEmpty()) {
+            getSeedProvider().onFail(SEED_FAILURES.poll());
+        }
     }
 
     @Override

--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -118,9 +118,9 @@ public class Atum implements ClientModInitializer {
                 stopRunning();
                 if (client.world == null) client.openScreen(null);
             }
-        }
-        while (!SEED_FAILURES.isEmpty()) {
-            getSeedProvider().onFail(SEED_FAILURES.poll());
+            while (!SEED_FAILURES.isEmpty()) {
+                getSeedProvider().onFail(SEED_FAILURES.poll());
+            }
         }
     }
 

--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -1,5 +1,6 @@
 package me.voidxwalker.autoreset;
 
+import io.netty.util.internal.ConcurrentSet;
 import me.voidxwalker.autoreset.api.seedprovider.AtumWaitingScreen;
 import me.voidxwalker.autoreset.api.seedprovider.SeedProvider;
 import net.fabricmc.api.ClientModInitializer;
@@ -11,8 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
 
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public class Atum implements ClientModInitializer {
@@ -26,6 +26,7 @@ public class Atum implements ClientModInitializer {
     private static boolean running = false;
     private static boolean shouldReset;
 
+    public static final Set<CompletableFuture<String>> SEED_FUTURES = new ConcurrentSet<>();
     private static final SeedProvider DEFAULT_SEED_PROVIDER = () -> CompletableFuture.completedFuture(Atum.config.seed);
     private static SeedProvider seedProvider = DEFAULT_SEED_PROVIDER;
 
@@ -44,6 +45,7 @@ public class Atum implements ClientModInitializer {
         shouldReset = false;
         running = false;
         config.dataPackMismatch = false;
+        cancelAllSeeds();
     }
 
     public static void scheduleReset() {
@@ -97,6 +99,11 @@ public class Atum implements ClientModInitializer {
 
     public static void ensureState(boolean condition, String exceptionMessage) throws IllegalStateException {
         if (!condition) throw new IllegalStateException(exceptionMessage);
+    }
+
+    public static void cancelAllSeeds(){
+        // Copy the collection to avoid modification during iteration
+        new ArrayList<>(SEED_FUTURES).forEach(f -> f.cancel(true));
     }
 
     @Override

--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -12,7 +12,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class Atum implements ClientModInitializer {
@@ -101,7 +103,7 @@ public class Atum implements ClientModInitializer {
         if (!condition) throw new IllegalStateException(exceptionMessage);
     }
 
-    public static void cancelAllSeeds(){
+    public static void cancelAllSeeds() {
         // Copy the collection to avoid modification during iteration
         new ArrayList<>(SEED_FUTURES).forEach(f -> f.cancel(true));
     }

--- a/src/main/java/me/voidxwalker/autoreset/Atum.java
+++ b/src/main/java/me/voidxwalker/autoreset/Atum.java
@@ -13,6 +13,7 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public class Atum implements ClientModInitializer {
     public static final Logger LOGGER = LogManager.getLogger();
@@ -25,7 +26,7 @@ public class Atum implements ClientModInitializer {
     private static boolean running = false;
     private static boolean shouldReset;
 
-    private static final SeedProvider DEFAULT_SEED_PROVIDER = () -> Optional.of(Atum.config.seed);
+    private static final SeedProvider DEFAULT_SEED_PROVIDER = () -> CompletableFuture.completedFuture(Atum.config.seed);
     private static SeedProvider seedProvider = DEFAULT_SEED_PROVIDER;
 
     public static void createNewWorld() {

--- a/src/main/java/me/voidxwalker/autoreset/AtumConfig.java
+++ b/src/main/java/me/voidxwalker/autoreset/AtumConfig.java
@@ -404,7 +404,7 @@ public class AtumConfig implements SpeedrunConfig {
         if (Atum.isRunning()) {
             throw new IllegalStateException("Cannot configure Atum while it's running.");
         }
-        return new AtumCreateWorldScreen(parent);
+        return new AtumCreateWorldScreen(parent, AtumCreateWorldScreen.Job.CONFIGURATION);
     }
 
     @Override

--- a/src/main/java/me/voidxwalker/autoreset/AtumCreateWorldScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/AtumCreateWorldScreen.java
@@ -5,8 +5,23 @@ import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import org.jetbrains.annotations.Nullable;
 
 public class AtumCreateWorldScreen extends CreateWorldScreen {
+    private final Job job;
 
     public AtumCreateWorldScreen(@Nullable Screen parent) {
+        this(parent, Job.CREATION);
+    }
+
+    public AtumCreateWorldScreen(@Nullable Screen parent, Job job) {
         super(parent);
+        this.job = job;
+    }
+
+    public Job getJob() {
+        return job;
+    }
+
+    public enum Job {
+        CREATION,
+        CONFIGURATION
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/AtumCreateWorldScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/AtumCreateWorldScreen.java
@@ -17,7 +17,7 @@ public class AtumCreateWorldScreen extends CreateWorldScreen {
     }
 
     public Job getJob() {
-        return job;
+        return this.job;
     }
 
     public enum Job {

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
@@ -10,8 +10,8 @@ import java.util.List;
  * A waiting screen intended to wait for a seed to become playable with the ability to cancel playing a seed.
  */
 public abstract class AtumWaitingScreen extends Screen {
-    private List<Runnable> onTick = new LinkedList<>();
-    private List<Runnable> onCancel = new LinkedList<>();
+    private final List<Runnable> onTick = new LinkedList<>();
+    private final List<Runnable> onCancel = new LinkedList<>();
 
     protected AtumWaitingScreen(Text title) {
         super(title);

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
@@ -32,11 +32,8 @@ public abstract class AtumWaitingScreen extends Screen {
         for (Runnable r : onCancel) r.run();
     }
 
-    /**
-     * If an implementation overrides tick, it needs to run super.tick().
-     */
     @Override
-    public void tick() {
+    public final void tick() {
         for (Runnable r : onTick) r.run();
     }
 

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
@@ -29,19 +29,23 @@ public abstract class AtumWaitingScreen extends Screen {
 
     @Override
     public final void onClose() {
-        for (Runnable r : onCancel) r.run();
+        for (Runnable r : this.onCancel) {
+            r.run();
+        }
     }
 
     @Override
     public final void tick() {
-        for (Runnable r : onTick) r.run();
+        for (Runnable r : this.onTick) {
+            r.run();
+        }
     }
 
     public final void addTickActivity(Runnable r) {
-        onTick.add(r);
+        this.onTick.add(r);
     }
 
     public final void addCancelActivity(Runnable r) {
-        onCancel.add(r);
+        this.onCancel.add(r);
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/AtumWaitingScreen.java
@@ -1,13 +1,17 @@
 package me.voidxwalker.autoreset.api.seedprovider;
 
-import me.voidxwalker.autoreset.Atum;
-import me.voidxwalker.autoreset.AtumCreateWorldScreen;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
 
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A waiting screen intended to wait for a seed to become playable with the ability to cancel playing a seed.
+ */
 public abstract class AtumWaitingScreen extends Screen {
-    private boolean decided = false;
+    private List<Runnable> onTick = new LinkedList<>();
+    private List<Runnable> onCancel = new LinkedList<>();
 
     protected AtumWaitingScreen(Text title) {
         super(title);
@@ -18,17 +22,6 @@ public abstract class AtumWaitingScreen extends Screen {
         this.onClose();
     }
 
-    @SuppressWarnings("unused")
-    protected final void continueWorldCreation() {
-        this.onDecided();
-        MinecraftClient.getInstance().openScreen(new AtumCreateWorldScreen(null));
-    }
-
-    private void onDecided() {
-        Atum.ensureState(!this.decided, "AtumWaitingScreen continue method(s) called more than once!");
-        this.decided = true;
-    }
-
     @Override
     public boolean shouldCloseOnEsc() {
         return false;
@@ -36,17 +29,22 @@ public abstract class AtumWaitingScreen extends Screen {
 
     @Override
     public final void onClose() {
-        this.onDecided();
-        Atum.stopRunning();
-        super.onClose();
+        for (Runnable r : onCancel) r.run();
     }
 
+    /**
+     * If an implementation overrides tick, it needs to run super.tick().
+     */
     @Override
-    public final void removed() {
-        Atum.ensureState(this.decided, "Improper closing of AtumWaitingScreen. Methods continueWorldCreation or cancelWorldCreation should be used.");
-        onRemoved();
+    public void tick() {
+        for (Runnable r : onTick) r.run();
     }
 
-    protected void onRemoved() {
+    public final void addTickActivity(Runnable r) {
+        onTick.add(r);
+    }
+
+    public final void addCancelActivity(Runnable r) {
+        onCancel.add(r);
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
@@ -29,6 +29,8 @@ public interface SeedProvider {
 
     /**
      * Runs when an exception or cancellation occurs while resolving the seed future.
+     * This method will be called individually for each exception with no guarantee of timing.
+     * This method is guaranteed to be called from the client thread.
      */
     @SuppressWarnings("unused")
     default void onFail(@Nullable Throwable ex) {

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
@@ -20,9 +20,8 @@ public interface SeedProvider {
     }
 
     /**
-     * Gets the waiting screen.
-     * The implemented waiting screen should run the provided continueWorldCreation method once a seed is available, or alternatively cancelWorldCreation.
-     * The implemented waiting screen can also override shouldCloseOnEsc(), returning true to allow cancelling with the 'escape' key.
+     * Gets the waiting screen. The implemented screen only needs to override the render method. It may also allow for
+     * cancelling of seeds with esc, or it can call cancelWorldCreation through other means such as a button.
      */
     default Optional<AtumWaitingScreen> getWaitingScreen() {
         return Optional.empty();

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
@@ -1,13 +1,16 @@
 package me.voidxwalker.autoreset.api.seedprovider;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public interface SeedProvider {
     /**
-     * Gets a seed if a seed is available, otherwise should return empty immediately.
-     * If empty can be returned, waitForSeed and getWaitingScreen should be implemented.
+     * Requests a seed from the seed provider. Can be completed immediately in the implemented method to skip any
+     * waiting screens.
      */
-    Optional<String> getSeed();
+    CompletableFuture<String> requestSeed();
 
     /**
      * Determines whether a set seed should be present in logs, LevelLoadingScreen, and DebugHUD.
@@ -17,17 +20,17 @@ public interface SeedProvider {
     }
 
     /**
-     * Waits for a seed to be available. This should only be called by Atum while using SeedQueue.
-     */
-    default void waitForSeed() {
-    }
-
-    /**
      * Gets the waiting screen.
      * The implemented waiting screen should run the provided continueWorldCreation method once a seed is available, or alternatively cancelWorldCreation.
      * The implemented waiting screen can also override shouldCloseOnEsc(), returning true to allow cancelling with the 'escape' key.
      */
-    default AtumWaitingScreen getWaitingScreen() {
-        throw new IllegalStateException("No waiting screen available!");
+    default Optional<AtumWaitingScreen> getWaitingScreen() {
+        return Optional.empty();
+    }
+
+    /**
+     * Runs when an exception or cancellation occurs while resolving the seed future.
+     */
+    default void onFail(@Nullable Throwable ex){
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
+++ b/src/main/java/me/voidxwalker/autoreset/api/seedprovider/SeedProvider.java
@@ -30,6 +30,7 @@ public interface SeedProvider {
     /**
      * Runs when an exception or cancellation occurs while resolving the seed future.
      */
-    default void onFail(@Nullable Throwable ex){
+    @SuppressWarnings("unused")
+    default void onFail(@Nullable Throwable ex) {
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/MinecraftClientMixin.java
@@ -138,6 +138,17 @@ public abstract class MinecraftClientMixin {
         Atum.stopRunning();
     }
 
+    @Inject(
+            method = "run",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/MinecraftClient;render(Z)V"
+            )
+    )
+    private void checkSeedFailures(CallbackInfo ci) {
+        Atum.checkSeedFailures();
+    }
+
     @Unique
     private boolean clickButton(Screen screen, String... translationKeys) {
         for (String translationKey : translationKeys) {

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -6,6 +6,7 @@ import me.contaria.speedrunapi.util.TextUtil;
 import me.voidxwalker.autoreset.AttemptTracker;
 import me.voidxwalker.autoreset.Atum;
 import me.voidxwalker.autoreset.AtumCreateWorldScreen;
+import me.voidxwalker.autoreset.AtumCreateWorldScreen.Job;
 import me.voidxwalker.autoreset.api.seedprovider.AtumWaitingScreen;
 import me.voidxwalker.autoreset.api.seedprovider.SeedProvider;
 import me.voidxwalker.autoreset.interfaces.IMoreOptionsDialog;
@@ -144,7 +145,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
         }
         ((IMoreOptionsDialog) this.moreOptionsDialog).atum$setSeed(seed);
 
-        if (Atum.isRunning()) {
+        if (isAtumReset()) {
             this.createWorld(seed);
             return;
         }
@@ -157,7 +158,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             at = @At("TAIL")
     )
     private void updateLevelNameField(boolean moreOptionsOpen, CallbackInfo ci) {
-        if (!Atum.isRunning() && this.isAtum()) {
+        if (isAtumConfig()) {
             this.levelNameField.setText(Atum.config.attemptTracker.getWorldName(
                     ((IMoreOptionsDialog) this.moreOptionsDialog).atum$isSetSeed() ? AttemptTracker.Type.SSG : AttemptTracker.Type.RSG
             ));
@@ -173,7 +174,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             cancellable = true
     )
     private void saveAtumConfigurations(CallbackInfo ci) {
-        if (!this.isAtum() || Atum.isRunning()) {
+        if (!isAtumConfig()) {
             return;
         }
 
@@ -192,7 +193,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
     )
     private boolean doNotUpdateEmptySaveFolderName(CreateWorldScreen screen) {
         // micro-optimization, we call updateSaveFolderName ourselves when creating the level
-        return !Atum.isRunning();
+        return !isAtumReset();
     }
 
     @WrapWithCondition(
@@ -271,7 +272,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
 
     @Unique
     private void initDataPacks() {
-        if (!Atum.isRunning()) {
+        if (isAtumConfig()) {
             this.dataPackTempDir = Atum.config.dataPackDirectory;
             return;
         }
@@ -295,7 +296,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
 
     @Unique
     private @Nullable String getSeed() {
-        if (!Atum.isRunning()) {
+        if (isAtumConfig()) {
             return Objects.requireNonNull(Atum.config.seed);
         }
         assert client != null;
@@ -327,6 +328,8 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 MinecraftClient.getInstance().openScreen(waitingScreen);
                 return null;
             }
+            // Job is already CREATION, we need to make sure we check atum is still running to prevent race conditions
+            // with mods that create worlds on other threads (seedqueue).
             if (!Atum.isRunning()) {
                 // Atum.stopRunning() may have ran right before this seedFuture was added to SEED_FUTURES, so if atum
                 // stopped running mid world creation, we should cancel this seed future to make sure this one is also
@@ -430,5 +433,17 @@ public abstract class CreateWorldScreenMixin extends Screen {
     @Unique
     private boolean isAtum() {
         return (Object) this instanceof AtumCreateWorldScreen;
+    }
+
+    @SuppressWarnings("all")
+    @Unique
+    private boolean isAtumConfig() {
+        return isAtum() && ((AtumCreateWorldScreen) (Object) this).getJob() == Job.CONFIGURATION;
+    }
+
+    @SuppressWarnings("all")
+    @Unique
+    private boolean isAtumReset() {
+        return isAtum() && ((AtumCreateWorldScreen) (Object) this).getJob() == Job.CREATION;
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -331,6 +331,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 // stopped running mid world creation, we should cancel this seed future to make sure this one is also
                 // caught.
                 seedFuture.cancel(true);
+                seedFuture.join(); // Move to CancellationException block or possibly the other exception block.
                 return null;
             }
             return seedFuture.join();

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -324,7 +324,13 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 MinecraftClient.getInstance().openScreen(waitingScreen);
                 return null;
             }
-            if (!Atum.isRunning()) return null;
+            if (!Atum.isRunning()) {
+                // Atum.stopRunning() may have ran right before this seedFuture was added to SEED_FUTURES, so if atum
+                // stopped running mid world creation, we should cancel this seed future to make sure this one is also
+                // caught.
+                seedFuture.cancel(true);
+                return null;
+            }
             return seedFuture.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -300,7 +300,13 @@ public abstract class CreateWorldScreenMixin extends Screen {
         assert client != null;
         try {
             SeedProvider seedProvider = Atum.getSeedProvider();
-            if (seedFuture == null) seedFuture = seedProvider.requestSeed();
+            if (seedFuture == null) {
+                seedFuture = seedProvider.requestSeed();
+                if (!seedFuture.isDone()) {
+                    Atum.SEED_FUTURES.add(seedFuture);
+                    seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(seedFuture));
+                }
+            }
             if (seedFuture.isDone()) {
                 return seedFuture.get();
             }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -302,10 +302,8 @@ public abstract class CreateWorldScreenMixin extends Screen {
             SeedProvider seedProvider = Atum.getSeedProvider();
             if (seedFuture == null) {
                 seedFuture = seedProvider.requestSeed();
-                if (!seedFuture.isDone()) {
-                    Atum.SEED_FUTURES.add(seedFuture);
-                    seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(seedFuture));
-                }
+                Atum.SEED_FUTURES.add(seedFuture);
+                seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(seedFuture));
             }
             if (seedFuture.isDone()) {
                 return seedFuture.get();
@@ -343,8 +341,9 @@ public abstract class CreateWorldScreenMixin extends Screen {
     @Unique
     private void onSeedFutureFail(Throwable ex) {
         assert client != null;
-        Atum.stopRunning();
+        Atum.cancelAllSeeds();
         client.execute(() -> {
+            Atum.stopRunning();
             client.openScreen(null);
             Atum.getSeedProvider().onFail(ex);
         });

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -44,6 +44,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -339,7 +340,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             Atum.LOGGER.warn("The seed has been cancelled.");
             onSeedFutureFail(e);
             return null;
-        } catch (Exception e) {
+        } catch (CompletionException e) {
             Atum.LOGGER.error("Failed to get seed from the seed provider!", e);
             onSeedFutureFail(e);
             return null;

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -145,7 +145,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
         }
         ((IMoreOptionsDialog) this.moreOptionsDialog).atum$setSeed(seed);
 
-        if (isAtumReset()) {
+        if (this.isAtumReset()) {
             this.createWorld(seed);
             return;
         }
@@ -158,7 +158,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             at = @At("TAIL")
     )
     private void updateLevelNameField(boolean moreOptionsOpen, CallbackInfo ci) {
-        if (isAtumConfig()) {
+        if (this.isAtumConfig()) {
             this.levelNameField.setText(Atum.config.attemptTracker.getWorldName(
                     ((IMoreOptionsDialog) this.moreOptionsDialog).atum$isSetSeed() ? AttemptTracker.Type.SSG : AttemptTracker.Type.RSG
             ));
@@ -174,7 +174,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             cancellable = true
     )
     private void saveAtumConfigurations(CallbackInfo ci) {
-        if (!isAtumConfig()) {
+        if (!this.isAtumConfig()) {
             return;
         }
 
@@ -193,7 +193,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
     )
     private boolean doNotUpdateEmptySaveFolderName(CreateWorldScreen screen) {
         // micro-optimization, we call updateSaveFolderName ourselves when creating the level
-        return !isAtumReset();
+        return !this.isAtumReset();
     }
 
     @WrapWithCondition(
@@ -272,7 +272,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
 
     @Unique
     private void initDataPacks() {
-        if (isAtumConfig()) {
+        if (this.isAtumConfig()) {
             this.dataPackTempDir = Atum.config.dataPackDirectory;
             return;
         }
@@ -296,21 +296,20 @@ public abstract class CreateWorldScreenMixin extends Screen {
 
     @Unique
     private @Nullable String getSeed() {
-        if (isAtumConfig()) {
+        if (this.isAtumConfig()) {
             return Objects.requireNonNull(Atum.config.seed);
         }
-        assert client != null;
         try {
             SeedProvider seedProvider = Atum.getSeedProvider();
-            if (seedFuture == null) {
-                seedFuture = seedProvider.requestSeed();
-                Atum.SEED_FUTURES.add(seedFuture);
-                seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(seedFuture));
+            if (this.seedFuture == null) {
+                this.seedFuture = seedProvider.requestSeed();
+                Atum.SEED_FUTURES.add(this.seedFuture);
+                this.seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(this.seedFuture));
             }
-            if (seedFuture.isDone()) {
+            if (this.seedFuture.isDone()) {
                 // Could do .get() but then we have to handle an extra exception type for no reason, .join() should
                 // immediately return because supposedly it isDone.
-                return seedFuture.join();
+                return this.seedFuture.join();
             }
             AtumWaitingScreen waitingScreen;
             if (MinecraftClient.getInstance().isOnThread() && (waitingScreen = Atum.getSeedProvider().getWaitingScreen().orElse(null)) != null) {
@@ -320,10 +319,12 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 // inherently thread-safe so the race won't cause any misbehavior, and cancelling an already completed
                 // seed future doesn't cause any issues, and the tick activity will simply reopen this screen and the
                 // seed future will resolve to whichever completion won the race.
-                waitingScreen.addCancelActivity(() -> seedFuture.cancel(true));
+                waitingScreen.addCancelActivity(() -> this.seedFuture.cancel(true));
                 waitingScreen.addTickActivity(() -> {
                     // Move back to this screen once the seed future is done, however it is done.
-                    if (seedFuture.isDone()) client.openScreen(this);
+                    if (this.seedFuture.isDone()) {
+                        MinecraftClient.getInstance().openScreen(this);
+                    }
                 });
                 MinecraftClient.getInstance().openScreen(waitingScreen);
                 return null;
@@ -334,11 +335,11 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 // Atum.stopRunning() may have ran right before this seedFuture was added to SEED_FUTURES, so if atum
                 // stopped running mid world creation, we should cancel this seed future to make sure this one is also
                 // caught.
-                seedFuture.cancel(true);
-                seedFuture.join(); // Move to CancellationException block or possibly the other exception block.
+                this.seedFuture.cancel(true);
+                this.seedFuture.join(); // Move to CancellationException block or possibly the other exception block.
                 return null;
             }
-            return seedFuture.join();
+            return this.seedFuture.join();
         } catch (CancellationException e) {
             Atum.LOGGER.warn("The seed has been cancelled.");
             onSeedFutureFail(e);
@@ -352,7 +353,6 @@ public abstract class CreateWorldScreenMixin extends Screen {
 
     @Unique
     private void onSeedFutureFail(Throwable ex) {
-        assert client != null;
         Atum.cancelAllSeeds();
         Atum.SEED_FAILURES.add(ex);
         if (MinecraftClient.getInstance().isOnThread()) {
@@ -438,15 +438,19 @@ public abstract class CreateWorldScreenMixin extends Screen {
         return (Object) this instanceof AtumCreateWorldScreen;
     }
 
-    @SuppressWarnings("all")
+    @SuppressWarnings("DataFlowIssue")
     @Unique
-    private boolean isAtumConfig() {
-        return isAtum() && ((AtumCreateWorldScreen) (Object) this).getJob() == Job.CONFIGURATION;
+    private Job getJob() {
+        return ((AtumCreateWorldScreen) (Object) this).getJob();
     }
 
-    @SuppressWarnings("all")
+    @Unique
+    private boolean isAtumConfig() {
+        return this.isAtum() && this.getJob() == Job.CONFIGURATION;
+    }
+
     @Unique
     private boolean isAtumReset() {
-        return isAtum() && ((AtumCreateWorldScreen) (Object) this).getJob() == Job.CREATION;
+        return this.isAtum() && this.getJob() == Job.CREATION;
     }
 }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -351,13 +351,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
     private void onSeedFutureFail(Throwable ex) {
         assert client != null;
         Atum.cancelAllSeeds();
-        client.execute(() -> {
-            if (Atum.isRunning()) {
-                Atum.stopRunning();
-                if (client.world == null) client.openScreen(null);
-            }
-            Atum.getSeedProvider().onFail(ex);
-        });
+        Atum.SEED_FAILURES.add(ex);
     }
 
     @Unique

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -324,6 +324,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 MinecraftClient.getInstance().openScreen(waitingScreen);
                 return null;
             }
+            if (!Atum.isRunning()) return null;
             return seedFuture.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -355,6 +355,9 @@ public abstract class CreateWorldScreenMixin extends Screen {
         assert client != null;
         Atum.cancelAllSeeds();
         Atum.SEED_FAILURES.add(ex);
+        if (MinecraftClient.getInstance().isOnThread()) {
+            Atum.checkSeedFailures();
+        }
     }
 
     @Unique

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -306,7 +306,9 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 seedFuture.handle((s, throwable) -> Atum.SEED_FUTURES.remove(seedFuture));
             }
             if (seedFuture.isDone()) {
-                return seedFuture.get();
+                // Could do .get() but then we have to handle an extra exception type for no reason, .join() should
+                // immediately return because supposedly it isDone.
+                return seedFuture.join();
             }
             AtumWaitingScreen waitingScreen;
             if (MinecraftClient.getInstance().isOnThread() && (waitingScreen = Atum.getSeedProvider().getWaitingScreen().orElse(null)) != null) {
@@ -332,8 +334,6 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 return null;
             }
             return seedFuture.join();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
         } catch (CancellationException e) {
             Atum.LOGGER.warn("The seed has been cancelled.");
             onSeedFutureFail(e);

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -350,8 +350,10 @@ public abstract class CreateWorldScreenMixin extends Screen {
         assert client != null;
         Atum.cancelAllSeeds();
         client.execute(() -> {
-            Atum.stopRunning();
-            if (client.world == null) client.openScreen(null);
+            if (Atum.isRunning()) {
+                Atum.stopRunning();
+                if (client.world == null) client.openScreen(null);
+            }
             Atum.getSeedProvider().onFail(ex);
         });
     }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -6,6 +6,7 @@ import me.contaria.speedrunapi.util.TextUtil;
 import me.voidxwalker.autoreset.AttemptTracker;
 import me.voidxwalker.autoreset.Atum;
 import me.voidxwalker.autoreset.AtumCreateWorldScreen;
+import me.voidxwalker.autoreset.api.seedprovider.AtumWaitingScreen;
 import me.voidxwalker.autoreset.api.seedprovider.SeedProvider;
 import me.voidxwalker.autoreset.interfaces.IMoreOptionsDialog;
 import net.minecraft.client.MinecraftClient;
@@ -40,8 +41,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -80,6 +82,8 @@ public abstract class CreateWorldScreenMixin extends Screen {
     @Shadow
     private ButtonWidget dataPacksButton;
 
+    @Unique
+    private CompletableFuture<String> seedFuture;
     @Unique
     private AbstractButtonWidget demoModeButton;
 
@@ -293,18 +297,51 @@ public abstract class CreateWorldScreenMixin extends Screen {
         if (!Atum.isRunning()) {
             return Objects.requireNonNull(Atum.config.seed);
         }
-        SeedProvider seedProvider = Atum.getSeedProvider();
-        Optional<String> seed = seedProvider.getSeed();
-        if (seed.isPresent()) {
-            return seed.get();
-        }
-        if (MinecraftClient.getInstance().isOnThread()) {
-            MinecraftClient.getInstance().openScreen(Atum.getSeedProvider().getWaitingScreen());
+        assert client != null;
+        try {
+            SeedProvider seedProvider = Atum.getSeedProvider();
+            if (seedFuture == null) seedFuture = seedProvider.requestSeed();
+            if (seedFuture.isDone()) {
+                return seedFuture.get();
+            }
+            AtumWaitingScreen waitingScreen;
+            if (MinecraftClient.getInstance().isOnThread() && (waitingScreen = Atum.getSeedProvider().getWaitingScreen().orElse(null)) != null) {
+                // When the waiting screen wants to cancel the seed, cancel the seed future, and then let the tick
+                // activity move us back to this screen. Technically this can be a race condition where the seed future
+                // completes as the waiting screen wants to cancel it. But this isn't really an issue, as futures are
+                // inherently thread-safe so the race won't cause any misbehavior, and cancelling an already completed
+                // seed future doesn't cause any issues, and the tick activity will simply reopen this screen and the
+                // seed future will resolve to whichever completion won the race.
+                waitingScreen.addCancelActivity(() -> seedFuture.cancel(true));
+                waitingScreen.addTickActivity(() -> {
+                    // Move back to this screen once the seed future is done, however it is done.
+                    if (seedFuture.isDone()) client.openScreen(this);
+                });
+                MinecraftClient.getInstance().openScreen(waitingScreen);
+                return null;
+            }
+            return seedFuture.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (CancellationException e) {
+            Atum.LOGGER.warn("The seed has been cancelled.");
+            onSeedFutureFail(e);
+            return null;
+        } catch (Exception e) {
+            Atum.LOGGER.error("Failed to get seed from the seed provider!", e);
+            onSeedFutureFail(e);
             return null;
         }
-        // Note: If a mod ever makes AtumCreateWorldScreens in parallel, the next two lines would cause a race condition.
-        seedProvider.waitForSeed();
-        return seedProvider.getSeed().orElseThrow(() -> new IllegalStateException("No seed found after waiting!"));
+    }
+
+    @Unique
+    private void onSeedFutureFail(Throwable ex) {
+        assert client != null;
+        Atum.stopRunning();
+        client.execute(() -> {
+            client.openScreen(null);
+            Atum.getSeedProvider().onFail(ex);
+        });
     }
 
     @Unique

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -344,7 +344,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
         Atum.cancelAllSeeds();
         client.execute(() -> {
             Atum.stopRunning();
-            client.openScreen(null);
+            if (client.world != null) client.openScreen(null);
             Atum.getSeedProvider().onFail(ex);
         });
     }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -344,7 +344,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
         Atum.cancelAllSeeds();
         client.execute(() -> {
             Atum.stopRunning();
-            if (client.world != null) client.openScreen(null);
+            if (client.world == null) client.openScreen(null);
             Atum.getSeedProvider().onFail(ex);
         });
     }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -342,11 +342,11 @@ public abstract class CreateWorldScreenMixin extends Screen {
             return this.seedFuture.join();
         } catch (CancellationException e) {
             Atum.LOGGER.warn("The seed has been cancelled.");
-            onSeedFutureFail(e);
+            this.onSeedFutureFail(e);
             return null;
         } catch (CompletionException e) {
             Atum.LOGGER.error("Failed to get seed from the seed provider!", e);
-            onSeedFutureFail(e);
+            this.onSeedFutureFail(e);
             return null;
         }
     }

--- a/src/main/java/me/voidxwalker/autoreset/mixin/gui/TitleScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/gui/TitleScreenMixin.java
@@ -40,7 +40,7 @@ public abstract class TitleScreenMixin extends Screen {
 
         this.addButton(new ButtonWidget(this.width / 2 - 124, this.height / 4 + 48, 20, 20, LiteralText.EMPTY, button -> {
             if (Screen.hasShiftDown()) {
-                MinecraftClient.getInstance().openScreen(new AtumCreateWorldScreen(this));
+                MinecraftClient.getInstance().openScreen(new AtumCreateWorldScreen(this, AtumCreateWorldScreen.Job.CONFIGURATION));
                 return;
             }
             Atum.scheduleReset();


### PR DESCRIPTION
The assumption of the previous iteration of SeedProvider was that waitForSeed and getSeed would only be called one at a time, with no two threads trying to race for the seed. SeedQueue unfortunately broke this promise due to a minor oversight.

These changes introduce a much more sensible version of SeedProvider using CompletableFutures, to let the implementation handle completion of the future however it deems fit. It also introduces proper handling for errors, cancelling the creation of seeds and returning to the main menu, and a new onFail method that seed providers can implement which is ran after full the cleanup is finished.

Tested village resetting RPS with all the changes and I hit the usual 110-115 so no noticeable impact on performance despite the potential added overhead. Most of the added code is never gonna be touched when using the default seed provider.

~~No changes to SeedQueue are needed.~~
In SeedQueue, the stopSeedQueueOnAtumStop mixin needs to be moved to `TAIL` to allow seeds to be canceled (for futures to be completed immediately and allow exiting): https://github.com/KingContaria/seedqueue/pull/86