### PR TITLE
[1.16.1] Run continueReset() on seed future completion instead of re-opening screen

### DIFF
--- a/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
+++ b/src/main/java/me/voidxwalker/autoreset/mixin/config/CreateWorldScreenMixin.java
@@ -139,18 +139,24 @@ public abstract class CreateWorldScreenMixin extends Screen {
             return;
         }
 
+        if (this.isAtumReset()) {
+            continueReset();
+            return;
+        }
+
+        ((IMoreOptionsDialog) this.moreOptionsDialog).atum$setSeed(Atum.config.seed);
+
+        this.initConfigScreen();
+    }
+
+    @Unique
+    private void continueReset() {
         String seed = this.getSeed();
         if (seed == null) {
             return;
         }
-        ((IMoreOptionsDialog) this.moreOptionsDialog).atum$setSeed(seed);
 
-        if (this.isAtumReset()) {
-            this.createWorld(seed);
-            return;
-        }
-
-        this.initConfigScreen();
+        this.createWorld(seed);
     }
 
     @Inject(
@@ -323,7 +329,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
                 waitingScreen.addTickActivity(() -> {
                     // Move back to this screen once the seed future is done, however it is done.
                     if (this.seedFuture.isDone()) {
-                        MinecraftClient.getInstance().openScreen(this);
+                        this.continueReset();
                     }
                 });
                 MinecraftClient.getInstance().openScreen(waitingScreen);
@@ -368,6 +374,7 @@ public abstract class CreateWorldScreenMixin extends Screen {
             MinecraftClient.getInstance().createWorld(demoWorldName, MinecraftServer.DEMO_LEVEL_INFO, RegistryTracker.create(), GeneratorOptions.DEMO_CONFIG);
             return;
         }
+        ((IMoreOptionsDialog) this.moreOptionsDialog).atum$setSeed(seed);
 
         // micro optimization, vanilla calls the changed listener twice,
         // once on setText and once on setCursorToEnd


### PR DESCRIPTION
Already present in #13 -> #22.
Could be considered a minor optimization.

In later versions it is an issue to re-open the same screen and rely on init() to run again.
The best solution I came up with was to abstract out some of the reset behavior into a continueReset() method.
I then ported this solution to earlier versions that didn't necessarily need it for consistency, and I figured I should also port it to 1.16.1.